### PR TITLE
Add .gitpod.yml, upgrade jacoco to 0.8.6

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image: gitpod/workspace-full-vnc
+# start up tasks
+
+tasks:
+  - init: 'echo export JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS -Dsun.java2d.xrender=false\" >>/home/gitpod/.bashrc'
+    command: 'source /home/gitpod/.bashrc && mvn package && java -jar target/*with-dependencies.jar'
+    
+ports:
+  - port: 6080
+    onOpen: open-preview

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Add support for GitPod, jacoco plugin (coverage) needed an upgrade to not complain on gitpod which uses Java 11 (Java 8+ still fine for project).